### PR TITLE
Fix Automated Builds on Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,38 +1,45 @@
 on:
   workflow_dispatch:
     # Special inputs go here... but we have none
-    
+
   push:
-    branches: [ main ]
+    branches: [main]
 
 name: Rust Build
 
 jobs:
   build:
-    name: Build for ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    name: Build on ${{ matrix.runner }}
     strategy:
       # If a build fails for a given platform, its probably gonna
       # fail on the other platforms as well. Just give up.
       fail-fast: true
 
-      # Specify targets to build for here
       matrix:
-        target: [
-          x86_64-pc-windows-gnu,
-          x86_64-unknown-linux-gnu
-        ]
+        runner: [windows-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.runner }}
 
     steps:
       # Checkout repository
       - uses: actions/checkout@v3
+
+      # Detect which platform we are running on and set the target triple accordingly
+      - name: Detect platform
+        id: detect_platform
+        shell: bash
+        run: |
+          case "${{ matrix.runner }}" in
+            ubuntu-latest)  echo "rustc_target=x86_64-unknown-linux-gnu" >> "$GITHUB_OUTPUT" ;;
+            windows-latest) echo "rustc_target=x86_64-pc-windows-msvc"   >> "$GITHUB_OUTPUT" ;;
+          esac
 
       # Get nightly toolchain
       - uses: actions-rs/toolchain@v1
         name: Install nightly toolchain
         with:
           toolchain: nightly
-          target: ${{ matrix.target }}
+          target: ${{ steps.detect_platform.outputs.rustc_target }}
 
       # Set default toolchain to nightly
       - name: "Set nightly as default toolchain"
@@ -44,7 +51,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --all-features --target ${{ matrix.target }} -Z unstable-options --out-dir "artifacts"
+          args: --release --all-features --target ${{ steps.detect_platform.outputs.rustc_target }} -Z unstable-options --out-dir "artifacts"
 
       # Run tests before we publish an artifact... just in case :)
       - uses: actions-rs/cargo@v1
@@ -52,7 +59,7 @@ jobs:
         with:
           use-cross: true
           command: test
-          args: --release --all-features --target ${{ matrix.target }}
+          args: --release --all-features --target ${{ steps.detect_platform.outputs.rustc_target }}
 
       # Get current version from Cargo.toml
       - uses: SebRollen/toml-action@v1.0.2
@@ -65,5 +72,5 @@ jobs:
       - uses: actions/upload-artifact@v3
         name: "Publish build"
         with:
-          name: mathy-notes_v${{ steps.read_project_version.outputs.value }}_${{ matrix.target }}
+          name: mathy-notes_v${{ steps.read_project_version.outputs.value }}_${{ steps.detect_platform.outputs.rustc_target }}
           path: artifacts/*

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you have feature requests, head over to the Issues page and let me know; this
 
 mathy-notes has pre-built binaries available in the Artifacts section of the **Rust Build** action. The following platforms are currently available:
 
-- Windows (`x86_64-pc-windows-gnu`)
+- Windows (`x86_64-pc-windows-msvc`)
 - GNU/Linux (`x86_64-unknown-linux-gnu`)
 
 > _Don't see your platform, but want a pre-built binary? Feel free to open an issue to request it :D_


### PR DESCRIPTION
Heck Wine, we'll just run the build on Windows. Uglier workflow, but not too much worse.

In short, we have a matrix that says we want the workflow to be run on "windows latest" and "ubuntu latest" (latest referring to the latest image GH Actions has, not the latest version of the respective OS). We detect the OS using a small bash script, and use that to write the correct target triple to an output (basically an environment variable). Everything else unchanged.

=)